### PR TITLE
Specify main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "tether",
   "version": "0.6.5",
   "description": "A client-side library to make absolutely positioned elements attach to elements in the page efficiently.",
+  "main": "tether.js",
   "authors": [
     "Zack Bloom <zackbloom@gmail.com>",
     "Adam Schwartz <adam.flynn.schwartz@gmail.com>"


### PR DESCRIPTION
Node's resolution algorithm (also used by Browserify) will only find your file if it's named `index.js` or if you specify `main` in `package.json`.