### PR TITLE
Remove Compass/Ruby dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,13 +1,13 @@
 {
   "name": "tether",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "tether.js",
   "homepage": "https://github.hubspot.com/tether",
   "authors": [
     "Zack Bloom <zackbloom@gmail.com>",
     "Adam Schwartz <adam.flynn.schwartz@gmail.com>"
   ],
-  "description": "Tether elements together",
+  "description": "A client-side library to make absolutely positioned elements attach to elements in the page efficiently.",
   "keywords": [
     "javascript"
   ],

--- a/css/tether-theme-arrows-dark.css
+++ b/css/tether-theme-arrows-dark.css
@@ -1,6 +1,4 @@
 .tether-element, .tether-element:after, .tether-element:before, .tether-element *, .tether-element *:after, .tether-element *:before {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box; }
 
 .tether-element {
@@ -13,15 +11,11 @@
   max-width: 100%;
   max-height: 100%; }
   .tether-element.tether-theme-arrows-dark .tether-content {
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    -ms-border-radius: 5px;
-    -o-border-radius: 5px;
     border-radius: 5px;
     position: relative;
     font-family: inherit;
-    background: black;
-    color: white;
+    background: #000;
+    color: #fff;
     padding: 1em;
     font-size: 1.1em;
     line-height: 1.5em; }
@@ -40,73 +34,73 @@
       top: 100%;
       left: 50%;
       margin-left: -16px;
-      border-top-color: black; }
+      border-top-color: #000; }
   .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-center .tether-content {
     margin-top: 16px; }
     .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-center .tether-content:before {
       bottom: 100%;
       left: 50%;
       margin-left: -16px;
-      border-bottom-color: black; }
+      border-bottom-color: #000; }
   .tether-element.tether-theme-arrows-dark.tether-element-attached-right.tether-element-attached-middle .tether-content {
     margin-right: 16px; }
     .tether-element.tether-theme-arrows-dark.tether-element-attached-right.tether-element-attached-middle .tether-content:before {
       left: 100%;
       top: 50%;
       margin-top: -16px;
-      border-left-color: black; }
+      border-left-color: #000; }
   .tether-element.tether-theme-arrows-dark.tether-element-attached-left.tether-element-attached-middle .tether-content {
     margin-left: 16px; }
     .tether-element.tether-theme-arrows-dark.tether-element-attached-left.tether-element-attached-middle .tether-content:before {
       right: 100%;
       top: 50%;
       margin-top: -16px;
-      border-right-color: black; }
+      border-right-color: #000; }
   .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-left.tether-target-attached-bottom .tether-content {
     margin-top: 16px; }
     .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-left.tether-target-attached-bottom .tether-content:before {
       bottom: 100%;
       left: 16px;
-      border-bottom-color: black; }
+      border-bottom-color: #000; }
   .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-right.tether-target-attached-bottom .tether-content {
     margin-top: 16px; }
     .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-right.tether-target-attached-bottom .tether-content:before {
       bottom: 100%;
       right: 16px;
-      border-bottom-color: black; }
+      border-bottom-color: #000; }
   .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-top .tether-content {
     margin-bottom: 16px; }
     .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-top .tether-content:before {
       top: 100%;
       left: 16px;
-      border-top-color: black; }
+      border-top-color: #000; }
   .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-top .tether-content {
     margin-bottom: 16px; }
     .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-top .tether-content:before {
       top: 100%;
       right: 16px;
-      border-top-color: black; }
+      border-top-color: #000; }
   .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-right.tether-target-attached-left .tether-content {
     margin-right: 16px; }
     .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-right.tether-target-attached-left .tether-content:before {
       top: 16px;
       left: 100%;
-      border-left-color: black; }
+      border-left-color: #000; }
   .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-left.tether-target-attached-right .tether-content {
     margin-left: 16px; }
     .tether-element.tether-theme-arrows-dark.tether-element-attached-top.tether-element-attached-left.tether-target-attached-right .tether-content:before {
       top: 16px;
       right: 100%;
-      border-right-color: black; }
+      border-right-color: #000; }
   .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-left .tether-content {
     margin-right: 16px; }
     .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-left .tether-content:before {
       bottom: 16px;
       left: 100%;
-      border-left-color: black; }
+      border-left-color: #000; }
   .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-right .tether-content {
     margin-left: 16px; }
     .tether-element.tether-theme-arrows-dark.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-right .tether-content:before {
       bottom: 16px;
       right: 100%;
-      border-right-color: black; }
+      border-right-color: #000; }

--- a/css/tether-theme-arrows.css
+++ b/css/tether-theme-arrows.css
@@ -1,6 +1,4 @@
 .tether-element, .tether-element:after, .tether-element:before, .tether-element *, .tether-element *:after, .tether-element *:before {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box; }
 
 .tether-element {
@@ -13,26 +11,18 @@
   max-width: 100%;
   max-height: 100%; }
   .tether-element.tether-theme-arrows .tether-content {
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    -ms-border-radius: 5px;
-    -o-border-radius: 5px;
     border-radius: 5px;
     position: relative;
     font-family: inherit;
-    background: white;
+    background: #fff;
     color: inherit;
     padding: 1em;
     font-size: 1.1em;
     line-height: 1.5em;
     -webkit-transform: translateZ(0);
-    -moz-transform: translateZ(0);
-    -ms-transform: translateZ(0);
-    -o-transform: translateZ(0);
-    transform: translateZ(0);
+            transform: translateZ(0);
     -webkit-filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2));
-    -moz-filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2));
-    filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2)); }
+            filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2)); }
     .tether-element.tether-theme-arrows .tether-content:before {
       content: "";
       display: block;
@@ -48,73 +38,73 @@
       top: 100%;
       left: 50%;
       margin-left: -16px;
-      border-top-color: white; }
+      border-top-color: #fff; }
   .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-center .tether-content {
     margin-top: 16px; }
     .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-center .tether-content:before {
       bottom: 100%;
       left: 50%;
       margin-left: -16px;
-      border-bottom-color: white; }
+      border-bottom-color: #fff; }
   .tether-element.tether-theme-arrows.tether-element-attached-right.tether-element-attached-middle .tether-content {
     margin-right: 16px; }
     .tether-element.tether-theme-arrows.tether-element-attached-right.tether-element-attached-middle .tether-content:before {
       left: 100%;
       top: 50%;
       margin-top: -16px;
-      border-left-color: white; }
+      border-left-color: #fff; }
   .tether-element.tether-theme-arrows.tether-element-attached-left.tether-element-attached-middle .tether-content {
     margin-left: 16px; }
     .tether-element.tether-theme-arrows.tether-element-attached-left.tether-element-attached-middle .tether-content:before {
       right: 100%;
       top: 50%;
       margin-top: -16px;
-      border-right-color: white; }
+      border-right-color: #fff; }
   .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-left.tether-target-attached-bottom .tether-content {
     margin-top: 16px; }
     .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-left.tether-target-attached-bottom .tether-content:before {
       bottom: 100%;
       left: 16px;
-      border-bottom-color: white; }
+      border-bottom-color: #fff; }
   .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-right.tether-target-attached-bottom .tether-content {
     margin-top: 16px; }
     .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-right.tether-target-attached-bottom .tether-content:before {
       bottom: 100%;
       right: 16px;
-      border-bottom-color: white; }
+      border-bottom-color: #fff; }
   .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-top .tether-content {
     margin-bottom: 16px; }
     .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-top .tether-content:before {
       top: 100%;
       left: 16px;
-      border-top-color: white; }
+      border-top-color: #fff; }
   .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-top .tether-content {
     margin-bottom: 16px; }
     .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-top .tether-content:before {
       top: 100%;
       right: 16px;
-      border-top-color: white; }
+      border-top-color: #fff; }
   .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-right.tether-target-attached-left .tether-content {
     margin-right: 16px; }
     .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-right.tether-target-attached-left .tether-content:before {
       top: 16px;
       left: 100%;
-      border-left-color: white; }
+      border-left-color: #fff; }
   .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-left.tether-target-attached-right .tether-content {
     margin-left: 16px; }
     .tether-element.tether-theme-arrows.tether-element-attached-top.tether-element-attached-left.tether-target-attached-right .tether-content:before {
       top: 16px;
       right: 100%;
-      border-right-color: white; }
+      border-right-color: #fff; }
   .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-left .tether-content {
     margin-right: 16px; }
     .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-right.tether-target-attached-left .tether-content:before {
       bottom: 16px;
       left: 100%;
-      border-left-color: white; }
+      border-left-color: #fff; }
   .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-right .tether-content {
     margin-left: 16px; }
     .tether-element.tether-theme-arrows.tether-element-attached-bottom.tether-element-attached-left.tether-target-attached-right .tether-content:before {
       bottom: 16px;
       right: 100%;
-      border-right-color: white; }
+      border-right-color: #fff; }

--- a/css/tether-theme-basic.css
+++ b/css/tether-theme-basic.css
@@ -1,6 +1,4 @@
 .tether-element, .tether-element:after, .tether-element:before, .tether-element *, .tether-element *:after, .tether-element *:before {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box; }
 
 .tether-element {
@@ -13,16 +11,10 @@
   max-width: 100%;
   max-height: 100%; }
   .tether-element.tether-theme-basic .tether-content {
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    -ms-border-radius: 5px;
-    -o-border-radius: 5px;
     border-radius: 5px;
-    -webkit-box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-    -moz-box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
     font-family: inherit;
-    background: white;
+    background: #fff;
     color: inherit;
     padding: 1em;
     font-size: 1.1em;

--- a/css/tether.css
+++ b/css/tether.css
@@ -1,6 +1,4 @@
 .tether-element, .tether-element:after, .tether-element:before, .tether-element *, .tether-element *:after, .tether-element *:before {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box; }
 
 .tether-element {

--- a/docs/css/intro.css
+++ b/docs/css/intro.css
@@ -1,7 +1,5 @@
 @charset "UTF-8";
 *, *:after, *:before {
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box; }
 
 body {
@@ -65,7 +63,8 @@ output {
     font-variant: small-caps;
     color: #777;
     opacity: 1;
-    transition: opacity 0.2s; }
+    -webkit-transition: opacity 0.2s;
+            transition: opacity 0.2s; }
   output.scrolled:after {
     opacity: 0; }
   output[deactivated], output[activated] {
@@ -169,6 +168,7 @@ span.attachment-mark:after, span.tether-marker-dot:after {
 [data-example^="optimizer"].lang-javascript {
   /* This should just be a `code` selector, but sass doesn't allow that with & */
   min-height: 220px; }
+
 [data-example^="optimizer"].tether-element:before {
   margin-top: 26px;
   display: block;
@@ -178,6 +178,7 @@ span.attachment-mark:after, span.tether-marker-dot:after {
   font-size: 15px;
   padding: 4px;
   color: #666; }
+
 [data-example^="optimizer"] .scroll-box .tether-element:before {
   content: "I'm in my scroll parent!"; }
 

--- a/docs/sass/intro.sass
+++ b/docs/sass/intro.sass
@@ -1,11 +1,16 @@
-@import compass/css3
-
 $scrollableArea: 2000px
 $exampleWidth: 400px
 $exampleHeight: 180px
 
+@mixin inline-block
+  display: inline-block
+  vertical-align: middle
+  *vertical-align: auto
+  *zoom: 1
+  *display: inline
+
 *, *:after, *:before
-  +box-sizing(border-box)
+  box-sizing: border-box
 
 body
   position: relative

--- a/docs/welcome/css/browser-demo.css
+++ b/docs/welcome/css/browser-demo.css
@@ -5,7 +5,7 @@ html, body {
 
 .tether.tether-theme-arrows-dark .tether-content {
   -webkit-filter: none;
-  filter: none;
+          filter: none;
   background: #000; }
   .tether.tether-theme-arrows-dark .tether-content ul {
     color: #fff;
@@ -23,8 +23,6 @@ html, body {
   bottom: 0;
   right: 0; }
   .browser-demo *, .browser-demo *:after, .browser-demo *:before {
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
     box-sizing: border-box; }
   .browser-demo .top {
     position: absolute;

--- a/docs/welcome/css/welcome.css
+++ b/docs/welcome/css/welcome.css
@@ -16,7 +16,7 @@ body {
   text-decoration: none;
   cursor: pointer;
   width: 140px;
-  font-size: 0.8em;
+  font-size: .8em;
   line-height: 1.3em;
   text-align: center; }
 
@@ -123,12 +123,8 @@ table.showcase {
     table.showcase.projects-showcase .showcase-inner .projects-list p {
       font-size: 1.3rem; }
   table.showcase.browser-demo {
-    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuMCIgeTE9IjAuMCIgeDI9IjEuMCIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzcyMzM2MiIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzlkMjIzYyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
-    background-size: 100%;
-    background-image: -webkit-gradient(linear, 0% 0%, 100% 100%, color-stop(0%, #723362), color-stop(100%, #9d223c));
-    background-image: -moz-linear-gradient(top left, #723362 0%, #9d223c 100%);
     background-image: -webkit-linear-gradient(top left, #723362 0%, #9d223c 100%);
-    background-image: linear-gradient(to bottom right, #723362 0%, #9d223c 100%);
+    background-image: linear-gradient(top left, #723362 0%, #9d223c 100%);
     background-color: #9d223c;
     position: absolute;
     top: 100%; }
@@ -140,10 +136,8 @@ table.showcase {
       right: 0;
       z-index: 1; }
       table.showcase.browser-demo.fixed .browser-demo-inner {
-        -moz-transition: width 2s ease-in-out, height 2s ease-in-out;
-        -o-transition: width 2s ease-in-out, height 2s ease-in-out;
         -webkit-transition: width 2s ease-in-out, height 2s ease-in-out;
-        transition: width 2s ease-in-out, height 2s ease-in-out; }
+                transition: width 2s ease-in-out, height 2s ease-in-out; }
       table.showcase.browser-demo.fixed[data-section="what"] {
         box-shadow: 0 0 0 0; }
       table.showcase.browser-demo.fixed[data-section="why"] .browser-demo-inner {
@@ -167,11 +161,8 @@ table.showcase {
       height: 100%;
       width: 100%; }
     table.showcase.browser-demo .section-copy {
-      -moz-transition: opacity 0.5s ease-in-out, top 0.5s ease-in-out;
-      -o-transition: opacity 0.5s ease-in-out, top 0.5s ease-in-out;
       -webkit-transition: opacity 0.5s ease-in-out, top 0.5s ease-in-out;
-      transition: opacity 0.5s ease-in-out, top 0.5s ease-in-out;
-      filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=0);
+              transition: opacity 0.5s ease-in-out, top 0.5s ease-in-out;
       opacity: 0;
       position: absolute;
       top: 0;
@@ -181,7 +172,6 @@ table.showcase {
       text-align: center;
       width: 100%; }
       table.showcase.browser-demo .section-copy.active {
-        filter: progid:DXImageTransform.Microsoft.Alpha(enabled=false);
         opacity: 1;
         top: -150px; }
         @media (max-width: 567px) {
@@ -196,8 +186,6 @@ table.showcase {
           table.showcase.browser-demo .section-copy h2 {
             font-size: 30px; } }
     table.showcase.browser-demo .browser-window {
-      -moz-border-radius: 4px;
-      -webkit-border-radius: 4px;
       border-radius: 4px;
       background: #fff;
       position: relative;
@@ -215,14 +203,12 @@ table.showcase {
         table.showcase.browser-demo .browser-window .browser-titlebar .browser-dots {
           padding: 16px; }
           table.showcase.browser-demo .browser-window .browser-titlebar .browser-dots b {
-            -moz-border-radius: 50%;
-            -webkit-border-radius: 50%;
-            border-radius: 50%;
             display: inline-block;
             vertical-align: middle;
             *vertical-align: auto;
             *zoom: 1;
             *display: inline;
+            border-radius: 50%;
             width: 10px;
             height: 10px;
             margin-right: 7px;
@@ -234,8 +220,6 @@ table.showcase {
         right: 0;
         bottom: 0; }
         table.showcase.browser-demo .browser-window .browser-frame iframe {
-          -moz-border-radius: 0 0 4px 4px;
-          -webkit-border-radius: 0;
           border-radius: 0 0 4px 4px;
           border: 0;
           width: 100%;
@@ -255,8 +239,6 @@ table.showcase {
       table.showcase.browser-demo-section .section-scroll-copy .section-scroll-copy-inner a {
         color: inherit; }
       table.showcase.browser-demo-section .section-scroll-copy .section-scroll-copy-inner .example-paragraph {
-        -moz-border-radius: 4px;
-        -webkit-border-radius: 4px;
         border-radius: 4px;
         background: #000;
         padding: 1rem; }

--- a/docs/welcome/sass/_inline-block.sass
+++ b/docs/welcome/sass/_inline-block.sass
@@ -1,0 +1,6 @@
+@mixin inline-block
+    display: inline-block
+    vertical-align: middle
+    *vertical-align: auto
+    *zoom: 1
+    *display: inline

--- a/docs/welcome/sass/browser-demo.sass
+++ b/docs/welcome/sass/browser-demo.sass
@@ -1,4 +1,4 @@
-@import compass/css3
+@import inline-block
 
 html, body
     height: 100%
@@ -6,7 +6,7 @@ html, body
     font-family: "proxima-nova", sans-serif
 
 .tether.tether-theme-arrows-dark .tether-content
-    +filter(none)
+    filter: none
     background: #000
 
     ul
@@ -26,7 +26,7 @@ html, body
     right: 0
 
     *, *:after, *:before
-        +box-sizing(border-box)
+        box-sizing: border-box
 
     .top
         position: absolute

--- a/docs/welcome/sass/welcome.sass
+++ b/docs/welcome/sass/welcome.sass
@@ -1,4 +1,4 @@
-@import compass/css3
+@import inline-block
 
 html, body
     height: 100%
@@ -140,7 +140,7 @@ table.showcase
                 font-size: 1.3rem
 
     &.browser-demo
-        +background-image(linear-gradient(top left, #723362 0%, #9d223c 100%))
+        background-image: linear-gradient(top left, #723362 0%, #9d223c 100%)
         background-color: #9d223c
         position: absolute
         top: 100%
@@ -154,7 +154,7 @@ table.showcase
             z-index: 1
 
             .browser-demo-inner
-                +transition(width 2s ease-in-out, height 2s ease-in-out)
+                transition: width 2s ease-in-out, height 2s ease-in-out
 
             // Sections
 
@@ -190,8 +190,8 @@ table.showcase
             width: 100%
 
         .section-copy
-            +transition(opacity .5s ease-in-out, top .5s ease-in-out)
-            +opacity(0)
+            transition: opacity .5s ease-in-out, top .5s ease-in-out
+            opacity: 0
             position: absolute
             top: 0
             position: absolute
@@ -201,7 +201,7 @@ table.showcase
             width: 100%
 
             &.active
-                +opacity(1)
+                opacity: 1
                 top: -150px
 
                 @media (max-width: 567px)
@@ -217,7 +217,7 @@ table.showcase
                     font-size: 30px
 
         .browser-window
-            +border-radius(4px)
+            border-radius: 4px
             background: #fff
             position: relative
             height: 100%
@@ -237,8 +237,8 @@ table.showcase
                     padding: 16px
 
                     b
-                        +border-radius(50%)
                         +inline-block
+                        border-radius: 50%
                         width: 10px
                         height: 10px
                         margin-right: 7px
@@ -252,7 +252,7 @@ table.showcase
                 bottom: 0
 
                 iframe
-                    +border-radius(0 0 4px 4px)
+                    border-radius: 0 0 4px 4px
                     border: 0
                     width: 100%
                     height: 100%
@@ -277,7 +277,7 @@ table.showcase
                     color: inherit
 
                 .example-paragraph
-                    +border-radius(4px)
+                    border-radius: 4px
                     background: #000
                     padding: 1rem
 

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -1,11 +1,12 @@
-gulp = require('gulp')
-coffee = require('gulp-coffee')
-compass = require('gulp-compass')
-concat = require('gulp-concat')
-uglify = require('gulp-uglify')
-header = require('gulp-header')
-rename = require('gulp-rename')
-wrap = require('gulp-wrap-umd')
+gulp      = require('gulp')
+coffee    = require('gulp-coffee')
+concat    = require('gulp-concat')
+header    = require('gulp-header')
+prefixer  = require('gulp-autoprefixer')
+rename    = require('gulp-rename')
+sass      = require('gulp-sass')
+uglify    = require('gulp-uglify')
+wrap      = require('gulp-wrap-umd')
 
 pkg = require('./package.json')
 banner = "/*! #{ pkg.name } #{ pkg.version } */\n"
@@ -45,21 +46,18 @@ gulp.task 'js', ->
     gulp.run 'concat', ->
       gulp.run 'uglify', ->
 
-gulp.task 'compass', ->
+gulp.task 'sass', ->
   for path in ['', 'docs/', 'docs/welcome/']
     gulp.src("./#{ path }sass/*")
-      .pipe(compass(
-        sass: "#{ path }sass"
-        css: "#{ path }css"
-        comments: false
-      ))
+      .pipe(sass())
+      .pipe(prefixer())
       .pipe(gulp.dest("./#{ path }css"))
 
 gulp.task 'default', ->
-  gulp.run 'js', 'compass'
+  gulp.run 'js', 'sass'
 
   gulp.watch './**/*.coffee', ->
     gulp.run 'js'
 
   gulp.watch './**/*.sass', ->
-    gulp.run 'compass'
+    gulp.run 'sass'

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
   "devDependencies": {
     "coffee-script": "~1.6.3",
     "gulp": "~3.3.0",
-    "gulp-header": "~1.0.2",
-    "gulp-uglify": "~0.1.0",
-    "gulp-compass": "~1.0.3",
+    "gulp-autoprefixer": "^2.2.0",
     "gulp-coffee": "~1.2.5",
     "gulp-concat": "~2.1.7",
+    "gulp-header": "~1.0.2",
     "gulp-rename": "~0.2.1",
+    "gulp-sass": "^2.0.0",
+    "gulp-uglify": "~0.1.0",
     "gulp-wrap-umd": "~0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tether",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A client-side library to make absolutely positioned elements attach to elements in the page efficiently.",
   "main": "tether.js",
   "authors": [

--- a/sass/helpers/_tether-theme-arrows.sass
+++ b/sass/helpers/_tether-theme-arrows.sass
@@ -1,12 +1,10 @@
-@import compass/css3
-
 =tether-theme-arrows($themePrefix: "tether", $themeName: "arrows", $arrowSize: 16px, $backgroundColor: #fff, $color: inherit, $useDropShadow: false)
     .#{ $themePrefix }-element.#{ $themePrefix }-theme-#{ $themeName }
         max-width: 100%
         max-height: 100%
 
         .#{ $themePrefix }-content
-            +border-radius(5px)
+            border-radius: 5px
             position: relative
             font-family: inherit
             background: $backgroundColor
@@ -16,8 +14,8 @@
             line-height: 1.5em
 
             @if $useDropShadow
-                +transform(translateZ(0))
-                +filter(drop-shadow(0 1px 4px rgba(0, 0, 0, .2)))
+                transform: translateZ(0)
+                filter: drop-shadow(0 1px 4px rgba(0, 0, 0, .2))
 
             &:before
                 content: ""

--- a/sass/helpers/_tether-theme-basic.sass
+++ b/sass/helpers/_tether-theme-basic.sass
@@ -1,13 +1,11 @@
-@import compass/css3
-
 =tether-theme-basic($themePrefix: "tether", $themeName: "basic", $backgroundColor: #fff, $color: inherit)
     .#{ $themePrefix }-element.#{ $themePrefix }-theme-#{ $themeName }
         max-width: 100%
         max-height: 100%
 
         .#{ $themePrefix }-content
-            +border-radius(5px)
-            +box-shadow(0 2px 8px rgba(0, 0, 0, .2))
+            border-radius: 5px
+            box-shadow: 0 2px 8px rgba(0, 0, 0, .2)
             font-family: inherit
             background: $backgroundColor
             color: $color

--- a/sass/helpers/_tether.sass
+++ b/sass/helpers/_tether.sass
@@ -1,10 +1,8 @@
-@import compass/css3
-
 =tether($themePrefix: "tether")
     .#{ $themePrefix }-element, .#{ $themePrefix }-element *
 
         &, &:after, &:before
-            +box-sizing(border-box)
+            box-sizing: border-box
 
     .#{ $themePrefix }-element
         position: absolute

--- a/sass/mixins/_inline-block.sass
+++ b/sass/mixins/_inline-block.sass
@@ -1,0 +1,6 @@
+@mixin inline-block
+  display: inline-block
+  vertical-align: middle
+  *vertical-align: auto
+  *zoom: 1
+  *display: inline

--- a/sass/mixins/_pie-clearfix.sass
+++ b/sass/mixins/_pie-clearfix.sass
@@ -1,0 +1,7 @@
+@mixin pie-clearfix
+  *zoom: 1
+
+  &:after
+    content: ""
+    display: table
+    clear: both

--- a/sass/mixins/_pointer-events.scss
+++ b/sass/mixins/_pointer-events.scss
@@ -1,6 +1,0 @@
-@mixin pointer-events($type: none) {
-    $type: unquote($type);
-    @include experimental(pointer-events, $type,
-        -moz, -webkit, not -o, not -ms, -khtml, official
-    );
-}


### PR DESCRIPTION
__[Progress]__: Ready to merge. Sanity checking.

Removes Compass + Ruby dependencies by replacing `gulp-compass` with `gulp-autoprefixer` and `gulp-sass`. Nothing really needed `compass`, so remove the extra, fairly bloated dependency making it harder to comtribute if Ruby + Compass are not installed.

Related https://github.com/HubSpot/tether/issues/80