### PR TITLE
Added repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "tether",
   "version": "1.0.2",
   "description": "A client-side library to make absolutely positioned elements attach to elements in the page efficiently.",
+  "repository": "HubSpot/tether",
   "authors": [
     "Zack Bloom <zackbloom@gmail.com>",
     "Adam Schwartz <adam.flynn.schwartz@gmail.com>"


### PR DESCRIPTION
Noticed that my `npm install` complained about tether not having a repository field, so I added one, as per https://docs.npmjs.com/files/package.json#repository