### PR TITLE
fixes crash when tether el is a doc frag

### DIFF
--- a/src/js/tether.js
+++ b/src/js/tether.js
@@ -734,7 +734,7 @@ class TetherClass {
       let offsetParentIsBody = true;
       let currentNode = this.element.parentNode;
       while (currentNode && currentNode.tagName !== 'BODY') {
-        if (getComputedStyle(currentNode).position !== 'static') {
+        if (currentNode.nodeType === 11 || getComputedStyle(currentNode).position !== 'static') {
           offsetParentIsBody = false;
           break;
         }


### PR DESCRIPTION
This fixes crash in getComputedStyle when element passed to Tether is a document fragment.