### PR TITLE
Fixing self-closing <script> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Or just download from the [releases](https://github.com/HubSpot/tether/releases)
 ## Usage
 You only need to include [tether.min.js](https://github.com/HubSpot/tether/blob/master/dist/js/tether.min.js) in your page:
 ```
-<script type="text/javascript" src="path/to/dist/js/tether.min.js" />
+<script src="path/to/dist/js/tether.min.js"></script>
 ```
 Or just use a CDN:
 ```


### PR DESCRIPTION
Including a self-closing script tag does no effect in HTML (but has in XML).So <script> tag is required to be closed explicitly.
Proofs: http://stackoverflow.com/questions/69913/why-dont-self-closing-script-tags-work
Tested with Chrome 50. The old <script> statement had no effect.
P.S.: In HTML5 there is no reason to write type="text/javascript".