### PR TITLE
Other self-closing <script> tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You only need to include [tether.min.js](https://github.com/HubSpot/tether/blob/
 ```
 Or just use a CDN:
 ```
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/tether/1.3.1/js/tether.min.js" />
+<script src="//cdnjs.cloudflare.com/ajax/libs/tether/1.3.1/js/tether.min.js"></script>
 ```
 
 The css files in the [dist/css](https://github.com/HubSpot/tether/tree/master/dist/css) folder are not required to get tether running.


### PR DESCRIPTION
Sorry, I forgot about the second self-closing tag in my first pull request. And unable to fix that pull request, since it's already closed.