### PR TITLE
Use browserify for building and add some tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root=true
+[*]
+indent_style=space
+indent_size=2
+trim_trailing_whitespace=true
+insert_final_newline=true

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,8 +1,6 @@
 var del         = require('del');
 var gulp        = require('gulp');
-var babel       = require('gulp-babel');
 var bump        = require('gulp-bump');
-var concat      = require('gulp-concat');
 var header      = require('gulp-header');
 var minify      = require('gulp-minify-css');
 var plumber     = require('gulp-plumber');
@@ -10,16 +8,14 @@ var prefixer    = require('gulp-autoprefixer');
 var rename      = require('gulp-rename');
 var uglify      = require('gulp-uglify');
 var sass        = require('gulp-sass');
-var umd         = require('gulp-wrap-umd');
+var browserify  = require('browserify');
+var source      = require('vinyl-source-stream');
+var buffer      = require('vinyl-buffer');
 
 // Variables
 var distDir = './dist';
 var pkg = require('./package.json');
 var banner = ['/*!', pkg.name, pkg.version, '*/\n'].join(' ');
-var umdOptions = {
-  exports: 'Tether',
-  namespace: 'Tether'
-};
 
 
 // Clean
@@ -30,17 +26,16 @@ gulp.task('clean', function() {
 
 // Javascript
 gulp.task('js', function() {
-  gulp.src([
-    './src/js/utils.js',
-    './src/js/tether.js',
-    './src/js/constraint.js',
-    './src/js/abutment.js',
-    './src/js/shift.js'
-  ])
+  browserify({
+    entries: [
+      './src/js/tether.js'
+    ],
+    standalone: 'Tether',
+    transform: ['babelify']
+  }).bundle()
     .pipe(plumber())
-    .pipe(babel())
-    .pipe(concat('tether.js'))
-    .pipe(umd(umdOptions))
+    .pipe(source('tether.js'))
+    .pipe(buffer())
     .pipe(header(banner))
 
     // Original

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,23 @@
+module.exports = function (config) {
+  config.set({
+    frameworks: ['mocha', 'browserify'],
+    files: [
+      'test/**/*.js'
+    ],
+    preprocessors: {
+      'test/**/*.js': 'browserify'
+    },
+    browserify: {
+      debug: true,
+      transform: ['babelify']
+    },
+    reporters: ['progress'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: false,
+    browsers: ['Chrome'],
+    singleRun: true,
+    concurrency: Infinity
+  });
+};

--- a/package.json
+++ b/package.json
@@ -22,19 +22,20 @@
   "license": "MIT",
   "main": "dist/js/tether.js",
   "devDependencies": {
+    "babelify": "^6.4.0",
+    "browserify": "^13.0.0",
     "del": "^2.0.2",
     "del-cli": "^0.2.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.0.1",
-    "gulp-babel": "^5.2.1",
     "gulp-bump": "^0.3.1",
-    "gulp-concat": "^2.6.0",
     "gulp-header": "^1.7.1",
     "gulp-minify-css": "^1.2.1",
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.0.4",
     "gulp-uglify": "^1.4.1",
-    "gulp-wrap-umd": "^0.2.1"
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "reinstall": "del node_modules && npm install",
     "watch": "gulp watch",
-    "build": "gulp build"
+    "build": "gulp build",
+    "test": "karma start karma.conf.js"
   },
   "repository": {
     "type": "git",
@@ -24,6 +25,7 @@
   "devDependencies": {
     "babelify": "^6.4.0",
     "browserify": "^13.0.0",
+    "chai": "^3.5.0",
     "del": "^2.0.2",
     "del-cli": "^0.2.0",
     "gulp": "^3.9.0",
@@ -35,7 +37,13 @@
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.0.4",
     "gulp-uglify": "^1.4.1",
+    "karma": "^0.13.22",
+    "karma-browserify": "^5.0.5",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-mocha": "^1.0.1",
+    "mocha": "^2.4.5",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "watchify": "^3.7.0"
   }
 }

--- a/src/js/abutment.js
+++ b/src/js/abutment.js
@@ -1,4 +1,4 @@
-/* globals TetherBase */
+import TetherBase from './utils';
 
 const {getBounds, updateClasses, defer} = TetherBase.Utils;
 

--- a/src/js/constraint.js
+++ b/src/js/constraint.js
@@ -1,4 +1,4 @@
-/* globals TetherBase */
+import TetherBase from './utils';
 
 const {
   getBounds,

--- a/src/js/markAttachment.js
+++ b/src/js/markAttachment.js
@@ -1,4 +1,4 @@
-/* globals Tether */
+import Tether from './tether';
 
 Tether.modules.push({
   initialize() {

--- a/src/js/shift.js
+++ b/src/js/shift.js
@@ -1,4 +1,4 @@
-/* globals TetherBase */
+import TetherBase from './utils';
 
 TetherBase.modules.push({
   position({top, left}) {

--- a/src/js/tether.js
+++ b/src/js/tether.js
@@ -1,8 +1,6 @@
-/* globals TetherBase, performance */
+/* globals performance */
 
-if (typeof TetherBase === 'undefined') {
-  throw new Error('You must include the utils.js file before tether.js');
-}
+import TetherBase from './utils';
 
 const {
   getScrollParents,
@@ -15,8 +13,13 @@ const {
   defer,
   flush,
   getScrollBarSize,
-  removeUtilElements
+  removeUtilElements,
+  Evented
 } = TetherBase.Utils;
+
+import './constraint';
+import './abutment';
+import './shift';
 
 function within(a, b, diff=1) {
   return (a + diff >= b && b >= a - diff);
@@ -789,3 +792,5 @@ TetherClass.modules = [];
 TetherBase.position = position;
 
 let Tether = extend(TetherClass, TetherBase);
+
+export default Tether;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,7 +1,4 @@
-let TetherBase;
-if (typeof TetherBase === 'undefined') {
-  TetherBase = {modules: []};
-}
+const TetherBase = {modules: []};
 
 let zeroElement = null;
 
@@ -340,3 +337,5 @@ TetherBase.Utils = {
   getScrollBarSize,
   removeUtilElements
 };
+
+export default TetherBase;

--- a/test/js/tether.js
+++ b/test/js/tether.js
@@ -1,0 +1,45 @@
+import Tether from '../../src/js/tether';
+
+import {expect} from 'chai'
+
+describe('Tether', () => {
+  describe('constructor', () => {
+    it('throws an error when the target and element are not specified', () => {
+      expect(() => {
+        new Tether({})
+      }).to.throw(Error)
+    })
+  });
+
+  describe('Utils', () => {
+    it('expose utility methods and constructors', () => {
+      expect(Tether.Utils).to.be.an('object')
+      expect(Tether.Utils.getScrollParents).to.be.a('function')
+      expect(Tether.Utils.getBounds).to.be.a('function')
+      expect(Tether.Utils.getOffsetParent).to.be.a('function')
+      expect(Tether.Utils.extend).to.be.a('function')
+      expect(Tether.Utils.addClass).to.be.a('function')
+      expect(Tether.Utils.removeClass).to.be.a('function')
+      expect(Tether.Utils.hasClass).to.be.a('function')
+      expect(Tether.Utils.updateClasses).to.be.a('function')
+      expect(Tether.Utils.defer).to.be.a('function')
+      expect(Tether.Utils.flush).to.be.a('function')
+      expect(Tether.Utils.uniqueId).to.be.a('function')
+      expect(Tether.Utils.Evented).to.be.a('function')
+      expect(Tether.Utils.getScrollBarSize).to.be.a('function')
+      expect(Tether.Utils.removeUtilElements).to.be.a('function')
+    })
+  })
+
+  describe('getClass', () => {}); // TODO: write tests
+  describe('setOptions', () => {}); // TODO: write tests
+  describe('getTargetBounds', () => {}); // TODO: write tests
+  describe('clearCache', () => {}); // TODO: write tests
+  describe('cache', () => {}); // TODO: write tests
+  describe('enable', () => {}); // TODO: write tests
+  describe('disable', () => {}); // TODO: write tests
+  describe('destroy', () => {}); // TODO: write tests
+  describe('updateAttachClasses', () => {}); // TODO: write tests
+  describe('position', () => {}); // TODO: write tests
+  describe('move', () => {}); // TODO: write tests
+});

--- a/test/js/utils.js
+++ b/test/js/utils.js
@@ -1,0 +1,48 @@
+import TetherBase from '../../src/js/utils';
+const {extend, addClass, hasClass, removeClass} = TetherBase.Utils;
+
+import {expect} from 'chai';
+
+describe('TetherBase', () => {
+  it('has the array of the modules', () => {
+    expect(TetherBase.modules).to.be.an('array')
+  })
+})
+
+describe('extend', () => {
+  it('returns the merged result of the given objects', () => {
+    expect(extend({a: 0}, {b: 1})).to.deep.equal({a: 0, b: 1});
+    expect(extend({a: 0}, {b: 1}, {c: 2})).to.deep.equal({a: 0, b: 1, c: 2});
+  });
+
+  it('extends the given objects', () => {
+    const obj = {foo: 0, bar: 1};
+    extend(obj, {foo: 2});
+    expect(obj).to.deep.equal({foo: 2, bar: 1});
+  });
+});
+
+describe('addClass', () => {
+  it('adds the given class name to the given element', () => {
+    expect(hasClass(document.body, 'add-class-test')).to.be.false;
+    addClass(document.body, 'add-class-test');
+    expect(hasClass(document.body, 'add-class-test')).to.be.true;
+  });
+});
+
+describe('hasClass', () => {
+  it('returns true if the element has the given class', () => {
+    expect(hasClass(document.body, 'has-class-test')).to.be.false;
+    document.body.setAttribute('class', 'has-class-test');
+    expect(hasClass(document.body, 'has-class-test')).to.be.true;
+  });
+});
+
+describe('removeClass', () => {
+  it('removes the given class from the given element', () => {
+    document.body.setAttribute('class', 'remove-class-test');
+    expect(hasClass(document.body, 'remove-class-test')).to.be.true;
+    removeClass(document.body, 'remove-class-test');
+    expect(hasClass(document.body, 'remove-class-test')).to.be.false;
+  });
+});


### PR DESCRIPTION
What I did in this PR:
- Introduced browserify for building the module. I think this is better than concatenating for keeping the modularity of the scripts.
  - `standalone: 'Tether'` option in browserify settings makes the bundle `umd`. `dist/js/tether(.min).js` must work as an umd module.
- Added test settings using karma test runner.
  - Added some easy test cases.
- Added .editorconfig
