### PR TITLE
[Fix] IE/Edge getClassName iframe support

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -226,7 +226,9 @@ function hasClass(el, name) {
 }
 
 function getClassName(el) {
-  if (el.className instanceof SVGAnimatedString) {
+  let ownerWindow = el.ownerDocument.defaultView;
+  
+  if (el.className instanceof ownerWindow.SVGAnimatedString) {
     return el.className.baseVal;
   }
   return el.className;


### PR DESCRIPTION
Currently the `getClassName` method uses an `instanceof` comparison using the top-level windows `SVGAnimatedString`. This will fail in IE/Edge in the case where the target node is within another `<iframe/>` or `<frame/>` element. 

This is easily fixed by simply comparing against the node's *owner window* `SVGAnimatedString` class instead, i.e.

```javascript
SVGAnimatedString // -> el.ownerDocument.defaultView.SVGAnimatedString
```