### PR TITLE
[Enhancement] Support nodes within other frames

### DIFF
--- a/src/js/constraint.js
+++ b/src/js/constraint.js
@@ -21,6 +21,7 @@ function getBoundingRect(tether, to) {
   }
 
   if (typeof to.nodeType !== 'undefined') {
+    const node = to;
     const size = getBounds(to);
     const pos = size;
     const style = getComputedStyle(to);

--- a/src/js/constraint.js
+++ b/src/js/constraint.js
@@ -26,7 +26,16 @@ function getBoundingRect(tether, to) {
     const style = getComputedStyle(to);
 
     to = [pos.left, pos.top, size.width + pos.left, size.height + pos.top];
-
+  
+    // Account any parent Frames scroll offset
+    if (node.ownerDocument !== document) {
+      let win = node.ownerDocument.defaultView;
+      to[0] += win.pageXOffset;
+      to[1] += win.pageYOffset;
+      to[2] += win.pageXOffset;
+      to[3] += win.pageYOffset;
+    }
+  
     BOUNDS_FORMAT.forEach((side, i) => {
       side = side[0].toUpperCase() + side.substr(1);
       if (side === 'Top' || side === 'Left') {

--- a/src/js/tether.js
+++ b/src/js/tether.js
@@ -391,7 +391,7 @@ class TetherClass extends Evented {
     this.enabled = true;
 
     this.scrollParents.forEach((parent) => {
-      if (parent !== document) {
+      if (parent !== this.target.ownerDocument) {
         parent.addEventListener('scroll', this.position);
       }
     })
@@ -571,23 +571,26 @@ class TetherClass extends Evented {
         right: pageXOffset - left - width + innerWidth
       }
     };
+    
+    var doc = this.target.ownerDocument;
+    var win = doc.defaultView;
 
     let scrollbarSize;
-    if (document.body.scrollWidth > window.innerWidth) {
+    if (doc.body.scrollWidth > win.innerWidth) {
       scrollbarSize = this.cache('scrollbar-size', getScrollBarSize);
       next.viewport.bottom -= scrollbarSize.height;
     }
 
-    if (document.body.scrollHeight > window.innerHeight) {
+    if (doc.body.scrollHeight > win.innerHeight) {
       scrollbarSize = this.cache('scrollbar-size', getScrollBarSize);
       next.viewport.right -= scrollbarSize.width;
     }
 
-    if (['', 'static'].indexOf(document.body.style.position) === -1 ||
-        ['', 'static'].indexOf(document.body.parentElement.style.position) === -1) {
+    if (['', 'static'].indexOf(doc.body.style.position) === -1 ||
+        ['', 'static'].indexOf(doc.body.parentElement.style.position) === -1) {
       // Absolute positioning in the body will be relative to the page, not the 'initial containing block'
-      next.page.bottom = document.body.scrollHeight - top - height;
-      next.page.right = document.body.scrollWidth - left - width;
+      next.page.bottom = doc.body.scrollHeight - top - height;
+      next.page.right = doc.body.scrollWidth - left - width;
     }
 
     if (typeof this.options.optimizations !== 'undefined' &&
@@ -603,8 +606,8 @@ class TetherClass extends Evented {
         offsetBorder[side.toLowerCase()] = parseFloat(offsetParentStyle[`border${ side }Width`]);
       });
 
-      offsetPosition.right = document.body.scrollWidth - offsetPosition.left - offsetParentSize.width + offsetBorder.right;
-      offsetPosition.bottom = document.body.scrollHeight - offsetPosition.top - offsetParentSize.height + offsetBorder.bottom;
+      offsetPosition.right = doc.body.scrollWidth - offsetPosition.left - offsetParentSize.width + offsetBorder.right;
+      offsetPosition.bottom = doc.body.scrollHeight - offsetPosition.top - offsetParentSize.height + offsetBorder.bottom;
 
       if (next.page.top >= (offsetPosition.top + offsetBorder.top) && next.page.bottom >= offsetPosition.bottom) {
         if (next.page.left >= (offsetPosition.left + offsetBorder.left) && next.page.right >= offsetPosition.right) {
@@ -759,7 +762,7 @@ class TetherClass extends Evented {
 
       if (!offsetParentIsBody) {
         this.element.parentNode.removeChild(this.element);
-        document.body.appendChild(this.element);
+        this.element.ownerDocument.body.appendChild(this.element);
       }
     }
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -36,7 +36,13 @@ function getScrollParents(el) {
     }
   }
 
-  parents.push(document.body);
+  parents.push(el.ownerDocument.body);
+  
+  // If the node is within a frame, account for the parent window scroll
+  if (el.ownerDocument !== document) {
+    parents.push(el.ownerDocument.defaultView);
+  }
+  
   return parents;
 }
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -246,7 +246,9 @@ function hasClass(el, name) {
 }
 
 function getClassName(el) {
-  if (el.className instanceof SVGAnimatedString) {
+  // Can't use just SVGAnimatedString here since nodes within a Frame in IE have
+  // completely separately SVGAnimatedString base classes
+  if (el.className instanceof el.ownerDocument.defaultView.SVGAnimatedString) {
     return el.className.baseVal;
   }
   return el.className;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -111,6 +111,19 @@ function getBounds(el) {
     box[k] = rect[k];
   }
 
+  // Take into account DOMElements that reside in another Frame by adjusting the
+  // getBoundingClientRect properties by the outer Frame's getBoundingClientRect offset
+  if (doc !== document) {
+    let frameElement = doc.defaultView.frameElement;
+    if (frameElement) {
+      let frameRect = getBounds(frameElement);
+      box.top += frameRect.top;
+      box.bottom += frameRect.top;
+      box.left += frameRect.left;
+      box.right += frameRect.left;
+    }
+  }
+
   const origin = getOrigin();
 
   box.top -= origin.top;


### PR DESCRIPTION
Take into account DOMElements that reside in another `Frame` by adjusting the `getBoundingClientRect` properties by the outer `Frame`'s `getBoundingClientRect` offset