### PR TITLE
Correctly detect scrollbars when positioning the element

### DIFF
--- a/src/js/tether.js
+++ b/src/js/tether.js
@@ -576,12 +576,12 @@ class TetherClass extends Evented {
     var win = doc.defaultView;
 
     let scrollbarSize;
-    if (doc.body.scrollWidth > win.innerWidth) {
+    if (win.innerHeight > doc.documentElement.clientHeight) {
       scrollbarSize = this.cache('scrollbar-size', getScrollBarSize);
       next.viewport.bottom -= scrollbarSize.height;
     }
 
-    if (doc.body.scrollHeight > win.innerHeight) {
+    if (win.innerWidth > doc.documentElement.clientWidth) {
       scrollbarSize = this.cache('scrollbar-size', getScrollBarSize);
       next.viewport.right -= scrollbarSize.width;
     }


### PR DESCRIPTION
The previous method of detecting scrollbars when positioning the element was unreliable. For example, it did not handle the case when the overflow on the body was 'scroll'.
Use a different method of detecting scrollbars which is more robust.

See https://tylercipriani.com/2014/07/12/crossbrowser-javascript-scrollbar-detection.html for more info on scrollbar detection. We only need the "Modern solution" here because of Tether's browser support.

I reproduced the issue with the `react-tether` library (see my [CodePen](http://codepen.io/shw6rn/pen/yJbVkz)) but I've confirmed it is a problem with Tether.

