### PR TITLE
tether.js: Fix capitalization of WebkitTransform

### DIFF
--- a/src/js/tether.js
+++ b/src/js/tether.js
@@ -28,7 +28,7 @@ const transformKey = (() => {
   }
   const el = document.createElement('div');
 
-  const transforms = ['transform', 'webkitTransform', 'OTransform', 'MozTransform', 'msTransform'];
+  const transforms = ['transform', 'WebkitTransform', 'OTransform', 'MozTransform', 'msTransform'];
   for (let i = 0; i < transforms.length; ++i) {
     const key = transforms[i];
     if (el.style[key] !== undefined) {


### PR DESCRIPTION
Per comment in https://github.com/Modernizr/Modernizr/blob/master/src/omPrefixes.js, `WebkitTransform` is technically correct.