### PR TITLE
Add overlay value to overflow to detect scroll parent

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -55,7 +55,7 @@ function getScrollParents(el) {
     }
 
     const {overflow, overflowX, overflowY} = style;
-    if (/(auto|scroll)/.test(overflow + overflowY + overflowX)) {
+    if (/(auto|scroll|overlay)/.test(overflow + overflowY + overflowX)) {
       if (position !== 'absolute' || ['relative', 'absolute', 'fixed'].indexOf(style.position) >= 0) {
         parents.push(parent)
       }


### PR DESCRIPTION
`overflow: overlay;` is non-standard value ( http://quirksmode.org/css/css2/overflow.html ), but it works now for WebKit browsers, so I think it can be nice to make tether works with it. 