### PR TITLE
fixing #217 - performance.now is null

### DIFF
--- a/src/js/tether.js
+++ b/src/js/tether.js
@@ -47,7 +47,7 @@ const position = () => {
 };
 
 function now() {
-  if (typeof performance !== 'undefined' && typeof performance.now !== 'undefined') {
+  if (performance && performance.now) {
     return performance.now();
   }
   return +new Date;


### PR DESCRIPTION
currently code causing :

> Uncaught TypeError: Object [object Performance] has no method 'now',

since performance exist, yet now is null.

And It has been fixed the same in other projects as well, e.g: 

https://github.com/lvivski/animatic/commit/88c604e32f83cccd0170d7d56a54057c931ed9f8

useragent that got it : 

Android Browser 4 on Android (Jelly Bean)
Samsung Galaxy S III (GT-I9300)