### PR TITLE
Guard against performance.now being unavailable

### DIFF
--- a/src/js/tether.js
+++ b/src/js/tether.js
@@ -47,7 +47,7 @@ const position = () => {
 };
 
 function now() {
-  if (performance && performance.now) {
+  if (typeof performance === 'object' && typeof performance.now === 'function') {
     return performance.now();
   }
   return +new Date;


### PR DESCRIPTION
Older versions of Safari and Firefox don't define `performance`. This PR prevents errors from being thrown when that's the case.

Related to [#217](https://github.com/HubSpot/tether/issues/217#issuecomment-346016464)